### PR TITLE
Provide libicuuc to linker

### DIFF
--- a/ac_check_icu.m4
+++ b/ac_check_icu.m4
@@ -26,7 +26,7 @@ AC_DEFUN([AC_CHECK_ICU],
 			  ICU_VERSION=`$pkgconfigpath --modversion icu-i18n`
 			  ICU_CPPFLAGS=""
 			  ICU_CFLAGS=`$pkgconfigpath --cflags icu-i18n`
-			  ICU_LIBS=`$pkgconfigpath --libs icu-i18n`
+			  ICU_LIBS=`$pkgconfigpath --libs icu-i18n icu-uc`
 		      else
 			  AC_MSG_RESULT([not found])
 		      fi


### PR DESCRIPTION
Building YAZ on openSUSE Tumbleweed failed with this error when linking "yaz-icu":

undefined reference to symbol 'ucnv_getDefaultName_76'
/usr/lib64/libicuuc.so.76: error adding symbols: DSO missing from command line

As far as I understand it the linker wants to have the transitive dependency made explicit and adding it to the m4 config seemed liked the earliest possible opportunity to achieve that goal.